### PR TITLE
files that are larger than the 1MB limit allowed in the dbfs put API …

### DIFF
--- a/dbx/sync/clients.py
+++ b/dbx/sync/clients.py
@@ -97,7 +97,7 @@ class BaseClient(ABC):
             more_opts = {"ssl": ssl} if ssl is not None else {}
             async with session.post(url=url, json=json_data, headers=headers, **more_opts) as resp:
                 if resp.status in ok_status:
-                    break
+                    return await resp.json()
                 if resp.status == 429:
                     dbx_echo("Rate limited")
                     await _rate_limit_sleep(resp)
@@ -196,14 +196,49 @@ class DBFSClient(BaseClient):
         path = f"{self.base_path}/{sub_path}"
         with open(full_source_path, "rb") as f:
             contents = base64.b64encode(f.read()).decode("ascii")
-        await self._api_put(
-            api_base_path=self.api_base_path,
-            path=path,
-            session=session,
-            api_token=self.api_token,
-            contents=contents,
-            ssl=self.ssl,
-        )
+
+        if len(contents) <= 1024 * 1024:
+            await self._api_put(
+                api_base_path=self.api_base_path,
+                path=path,
+                session=session,
+                api_token=self.api_token,
+                contents=contents,
+                ssl=self.ssl,
+            )
+        else:
+            dbx_echo(f"Streaming {path}")
+
+            resp = await self._api(
+                url=f"{self.api_base_path}/create",
+                path=path,
+                session=session,
+                api_token=self.api_token,
+                ssl=self.ssl,
+                overwrite=True,
+            )
+            handle = resp.get("handle")
+            import textwrap
+
+            chunks = textwrap.wrap(contents, 1024 * 1024)
+            for chunk in chunks:
+                await self._api(
+                    url=f"{self.api_base_path}/add-block",
+                    path=path,
+                    session=session,
+                    api_token=self.api_token,
+                    ssl=self.ssl,
+                    handle=handle,
+                    data=chunk,
+                )
+            await self._api(
+                url=f"{self.api_base_path}/close",
+                path=path,
+                session=session,
+                api_token=self.api_token,
+                ssl=self.ssl,
+                handle=handle,
+            )
 
 
 class ReposClient(BaseClient):

--- a/tests/unit/sync/clients/conftest.py
+++ b/tests/unit/sync/clients/conftest.py
@@ -18,3 +18,12 @@ def dummy_file_path() -> str:
         with open(file_path, "w") as f:
             f.write("yo")
         yield file_path
+
+
+@pytest.fixture
+def dummy_file_path_2mb() -> str:
+    with temporary_directory() as tempdir:
+        file_path = os.path.join(tempdir, "file")
+        with open(file_path, "w") as f:
+            f.write("y" * 1024 * 2048)
+        yield file_path

--- a/tests/unit/sync/clients/test_repos_client.py
+++ b/tests/unit/sync/clients/test_repos_client.py
@@ -31,7 +31,7 @@ def test_init(mock_config):
 
 def test_delete(client: ReposClient):
     session = MagicMock()
-    resp = MagicMock()
+    resp = AsyncMock()
     setattr(type(resp), "status", PropertyMock(return_value=200))
     session.post.return_value = create_async_with_result(resp)
     asyncio.run(client.delete(sub_path="foo/bar", session=session))
@@ -48,7 +48,7 @@ def test_delete_secure(client: ReposClient):
     mock_config = mocked_props(token="fake-token", host="http://fakehost.asdf/base/", insecure=False)
     client = ReposClient(user="foo@somewhere.com", repo_name="my-repo", config=mock_config)
     session = MagicMock()
-    resp = MagicMock()
+    resp = AsyncMock()
     setattr(type(resp), "status", PropertyMock(return_value=200))
     session.post.return_value = create_async_with_result(resp)
     asyncio.run(client.delete(sub_path="foo/bar", session=session))
@@ -63,7 +63,7 @@ def test_delete_insecure(client: ReposClient):
     mock_config = mocked_props(token="fake-token", host="http://fakehost.asdf/base/", insecure=True)
     client = ReposClient(user="foo@somewhere.com", repo_name="my-repo", config=mock_config)
     session = MagicMock()
-    resp = MagicMock()
+    resp = AsyncMock()
     setattr(type(resp), "status", PropertyMock(return_value=200))
     session.post.return_value = create_async_with_result(resp)
     asyncio.run(client.delete(sub_path="foo/bar", session=session))
@@ -91,7 +91,7 @@ def test_delete_no_path(client: ReposClient):
 
 def test_delete_recursive(client: ReposClient):
     session = MagicMock()
-    resp = MagicMock()
+    resp = AsyncMock()
     setattr(type(resp), "status", PropertyMock(return_value=200))
     session.post.return_value = create_async_with_result(resp)
     asyncio.run(client.delete(sub_path="foo/bar", session=session, recursive=True))
@@ -107,7 +107,7 @@ def test_delete_rate_limited(client: ReposClient):
     rate_limit_resp = MagicMock()
     setattr(type(rate_limit_resp), "status", PropertyMock(return_value=429))
 
-    success_resp = MagicMock()
+    success_resp = AsyncMock()
     setattr(type(success_resp), "status", PropertyMock(return_value=200))
     setattr(type(rate_limit_resp), "headers", PropertyMock(return_value={"Retry-After": None}))
 
@@ -127,7 +127,7 @@ def test_delete_rate_limited_retry_after(client: ReposClient):
     setattr(type(rate_limit_resp), "status", PropertyMock(return_value=429))
     setattr(type(rate_limit_resp), "headers", PropertyMock(return_value={"Retry-After": 1}))
 
-    success_resp = MagicMock()
+    success_resp = AsyncMock()
     setattr(type(success_resp), "status", PropertyMock(return_value=200))
 
     session.post.side_effect = [create_async_with_result(rate_limit_resp), create_async_with_result(success_resp)]
@@ -155,7 +155,7 @@ def test_delete_unauthorized(client: ReposClient):
 
 def test_mkdirs(client: ReposClient):
     session = MagicMock()
-    resp = MagicMock()
+    resp = AsyncMock()
     setattr(type(resp), "status", PropertyMock(return_value=200))
     session.post.return_value = create_async_with_result(resp)
     asyncio.run(client.mkdirs(sub_path="foo/bar", session=session))
@@ -188,7 +188,7 @@ def test_mkdirs_rate_limited(client: ReposClient):
     rate_limit_resp = MagicMock()
     setattr(type(rate_limit_resp), "status", PropertyMock(return_value=429))
 
-    success_resp = MagicMock()
+    success_resp = AsyncMock()
     setattr(type(success_resp), "status", PropertyMock(return_value=200))
     setattr(type(rate_limit_resp), "headers", PropertyMock(return_value={"Retry-After": None}))
 
@@ -208,7 +208,7 @@ def test_mkdirs_rate_limited_retry_after(client: ReposClient):
     setattr(type(rate_limit_resp), "status", PropertyMock(return_value=429))
     setattr(type(rate_limit_resp), "headers", PropertyMock(return_value={"Retry-After": 1}))
 
-    success_resp = MagicMock()
+    success_resp = AsyncMock()
     setattr(type(success_resp), "status", PropertyMock(return_value=200))
 
     session.post.side_effect = [create_async_with_result(rate_limit_resp), create_async_with_result(success_resp)]


### PR DESCRIPTION
…v2.0 will use the streaming api calls to upload the content and avoid the http 400 MAX_BLOCK_SIZE_EXCEEDED error

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers. If it fixes a bug or resolves a feature request, please provide a link to that issue.

## Types of changes

What types of changes does your code introduce to dbx?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
